### PR TITLE
Added footmisc LaTeX package dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Why settle for MS Word when you can get the job done using your text editor?
 
 ## Dependencies
 
-1. LaTeX with the following extra packages: `fontspec` `geometry` `ragged2e` `enumitem` `xunicode` `xltxtra` `hyperref` `polyglossia`
+1. LaTeX with the following extra packages: `fontspec` `geometry` `ragged2e` `enumitem` `xunicode` `xltxtra` `hyperref` `polyglossia` `footmisc`
 2. [Pandoc](http://pandoc.org/)
 
 To install LaTeX on Mac OS X, I recommend getting the smaller version BasicTeX from [here](https://tug.org/mactex/morepackages.html) and installing the additional packages with `tlmgr` afterwards. Same goes for Linux: install `texlive-base` with your package manager and add the needed additional packages later.


### PR DESCRIPTION
`footmisc` was needed after a install of BasicTeX, otherwise `footmisc.sty` is missing.
