### PR TITLE
Still print author name even if signature is missing

### DIFF
--- a/template.tex
+++ b/template.tex
@@ -117,12 +117,15 @@ $endif$
 
 $body$
 
-\IfFileExists{signature.pdf}
-{
-    \begin{FlushRight}
-      \includegraphics[height=5.5\baselineskip]{signature.pdf} \par
-      $author$
-    \end{FlushRight}
-}
+\begin{FlushRight}
+  \IfFileExists{signature.pdf}
+  {
+    \includegraphics[height=5.5\baselineskip]{signature.pdf} \par
+  }
+  {
+    \vspace{5.5\baselineskip}
+  }
+  $author$
+\end{FlushRight}
 
 \end{document}


### PR DESCRIPTION
I wanted to print my letter and then sign it by hand. For this, I still wanted my name to be printed with a little empty space for my signature.
This change leaves this space by default when there is no signature file. 
I'm not exactly sure if this is good as default behavior, maybe a switch in the YAML front matter would be nice to switch this on?
