### PR TITLE
Euro sign

### DIFF
--- a/template.tex
+++ b/template.tex
@@ -9,6 +9,10 @@
 \usepackage{geometry}
 \geometry{$geometry$}
 
+$if(euro)$
+  \usepackage{eurosym}
+$endif$
+
 % No page numbers
 \pagenumbering{gobble}
 


### PR DESCRIPTION
To use the euro sign I had to add 
```
$if(euro)$
  \usepackage{eurosym}
$endif$
```
to the tex template. Without I get an error when compiling.