### PR TITLE
Add Rmarkdown/RStudio support

### DIFF
--- a/letter.md
+++ b/letter.md
@@ -1,4 +1,8 @@
 ---
+output:
+  pdf_document:
+    template: template.tex
+    latex_engine: xelatex
 # subject: My life as a soldier
 author: F. Nietzsche
 city: Naumburg


### PR DESCRIPTION
adding the pandoc options to the YAML header allows Rmarkdown/RStudio
users to hit the "knit" button to compile to PDF (via pandoc). No make
file needed.