### PR TITLE
Switch from polyglossia to babel

### DIFF
--- a/letter.md
+++ b/letter.md
@@ -15,7 +15,7 @@ to:
 mainfont: Hoefler Text
 altfont: Helvetica Neue
 monofont: Courier
-lang: en-GB
+lang: english
 fontsize: 10pt
 geometry: a4paper, left=35mm, right=35mm, top=50mm, bottom=25mm
 # letterhead: true

--- a/template.tex
+++ b/template.tex
@@ -28,8 +28,7 @@ $endif$
 % LANGUAGE
 %--------------------------------
 $if(lang)$
-\usepackage{polyglossia}
-\setmainlanguage{$lang$}
+\usepackage[$lang$]{babel}
 $endif$
 
 % TYPOGRAPHY


### PR DESCRIPTION
Same fix as the one proposed in https://github.com/mrzool/invoice-boilerplate/issues/24

Here things may be trickier because there is some interaction between `babel` and `datetime2` as explained [here](https://distrib-coffee.ipsl.jussieu.fr/pub/mirrors/ctan/macros/latex/contrib/datetime2/datetime2.pdf). If I understand correcly, things should work out of the box because `babel` is loaded before `datetime2`, but I haven't actually tested.